### PR TITLE
detect more domains

### DIFF
--- a/auth-hook.py
+++ b/auth-hook.py
@@ -14,7 +14,7 @@ def main():
     api_url = "https://www.strato.de/apps/CustomerService"
     txt_key = "_acme-challenge"
     txt_value = os.environ["CERTBOT_VALIDATION"]
-    domain_name = re.search(r"(\w+\.\w+)$", os.environ["CERTBOT_DOMAIN"]).group(1)
+    domain_name = re.search(r"([^.]+\.\w+)$", os.environ["CERTBOT_DOMAIN"]).group(1)
 
     # setup session for cookie sharing
     http_session = requests.session()


### PR DESCRIPTION
`\w` only matches alphanumeric characters and underscores, other characters (e.g. '-') are not matched.
To detect domains with such characters, extend the regex to match everything except `.`.