### PR TITLE
Updated get_package_id search RegEx

### DIFF
--- a/certbotstratoapi.py
+++ b/certbotstratoapi.py
@@ -144,7 +144,7 @@ class CertbotStratoApi:
             'node': 'kds_CustomerEntryPage',
         })
         result = re.search(
-            r'<div class="package-information">\s+<span\s+class="domains_\d+_long">.+?'
+            r'<div class="package-information">.+?<span\s+class="domains_\d+_long[^>]*>.+?'
             + self.second_level_domain_name.replace('.', r'\.')
             + r'.+?cID=(?P<cID>\d+)',
             request.text.replace('\n', ' ')


### PR DESCRIPTION
Changed the RegEx to also fit this pattern:

`<div class="package-information">   <span class="domains_0000000_short">  xxxx.de<br>  xxxxxx-xxx-xxx.com<br>  <a class="cep_button_more clicker" data-auftragsnummer="0000000"><span class="fa fa-caret-right">&nbsp;</span>alle anzeigen</a> </span> <span class="domains_0000000_long hidden">  xxxx.de<br>  xxxxxx-xxx-xxx.com<br>  x-xx.eu<br>  xxxxxxx-xxxx.com<br>  xxxxxx-xxxxxxxx.com<br>  xxxxxx-xxxx.com<br>  xxxxxx.net<br>  xx-xxxxxx.info<br>  xxxx-xxxxxxxxx.de<br>  xxxx.net<br>  <a class="cep_button_less clicker" data-auftragsnummer="0000000"><span class="fa fa-caret-up">&nbsp;</span>weniger anzeigen</a> </span>    </div>`