### PR TITLE
Fix extraction of sessionID query parameter

### DIFF
--- a/certbotstratoapi.py
+++ b/certbotstratoapi.py
@@ -129,7 +129,8 @@ class CertbotStratoApi:
             totp_secret, totp_devicename)
 
         # Check successful login
-        query_parameters = urllib.parse.parse_qs(request.url)
+        parsed_url = urllib.parse.urlparse(request.url)
+        query_parameters = urllib.parse.parse_qs(parsed_url.query)
         if 'sessionID' not in query_parameters:
             return False
         self.session_id = query_parameters['sessionID'][0]


### PR DESCRIPTION
The previous code assumed the URL to be the query string. As a consequence the first query parameter was merged with the preceding URL segment. In my case this meant that the parameter `sessionID` was instead parsed as `https://www.strato.de/apps/CustomerService?sessionID`. Properly extracting the query part from the URL beforehand should solve this.

I honestly have not been able to completely test this as I ran into the ACME rate limit though it was failing at the login state before which after this change succeeds (running the auth-hook with `CERTBOT_VALIDATION=foobar` and `CERTBOT_DOMAIN=www.example.com`). If reminded I can check again once I can perform new requests.