### PR TITLE
Subdomain and cert manager compatibility

### DIFF
--- a/certbotstratoapi.py
+++ b/certbotstratoapi.py
@@ -18,13 +18,28 @@ class CertbotStratoApi:
             self.api_url = "https://www.strato.de/apps/CustomerService"
         else:
             self.api_url = api_url
-        self.txt_key = "_acme-challenge"
-        self.txt_value = os.environ["CERTBOT_VALIDATION"]
-        self.domain_name = os.environ["CERTBOT_DOMAIN"]
-        self.second_level_domain_name = re.search(
-            r"([\w-]+\.[\w-]+)$", self.domain_name
-        ).group(1)
+
+        self.acme_challenge_label = "_acme-challenge"
+
+        # Domain of the requested certificate
+        #   root-zone period and acme-challenge lable will be removed
+        # _acme-challenge.subdomain.example.com. -> subdomain.example.com
+        self.domain_name = re.sub(f"^{self.acme_challenge_label}\\.|\\.$", "", os.environ["CERTBOT_DOMAIN"])
+        # Second Level Domain:
+        # example.com
+        self.second_level_domain_name = re.search(r"([\w-]+\.[\w-]+)$",self.domain_name).group(1)
+        # Subdomain: All parts under the second level domain
+        # subdomain.example.com -> subdomain
         self.subdomain = self.extract_subdomain()
+
+        # TXT-Record key combination of acme-challenge label and subdomain if exists
+        self.txt_key = self.acme_challenge_label + ("" if len(self.subdomain) == 0 else "." + self.subdomain)
+        self.txt_value = os.environ["CERTBOT_VALIDATION"]
+
+        print(f"INFO: domain_name: {self.domain_name}")
+        print(f"INFO: second_level_domain_name: {self.second_level_domain_name}")
+        print(f"INFO: subdomain: {self.subdomain}")
+
         print(f"INFO: txt_key: {self.txt_key}")
         print(f"INFO: txt_value: {self.txt_value}")
         print(f"INFO: second_level_domain_name: {self.second_level_domain_name}")

--- a/certbotstratoapi.py
+++ b/certbotstratoapi.py
@@ -96,17 +96,12 @@ class CertbotStratoApi:
         # Set parameter 'action_customer_login.x'
         param["action_customer_login.x"] = 1
 
-        # No idea what this regex does
-        # TODO: rewrite with beautifulsoup
         # Set parameter pw_id
-        for device in re.finditer(
-            rf'<option value="(?P<value>(S\.{username}\.\w*))"'
-            r'( selected(="selected")?)?\s*>(?P<name>(.+?))</option>',
-            response.text,
-        ):
-            if totp_devicename.strip() == device.group("name").strip():
-                param["pw_id"] = device.group("value")
+        for device in soup.select(f"option[value*='{username}']"):
+            if totp_devicename.strip() == device.text.strip():
+                param["pw_id"] = device.attrs["value"]
                 break
+
         if param.get("pw_id") is None:
             print("ERROR: Parsing error on 2FA site by device name.")
             return response

--- a/certbotstratoapi.py
+++ b/certbotstratoapi.py
@@ -42,9 +42,6 @@ class CertbotStratoApi:
 
         print(f"INFO: txt_key: {self.txt_key}")
         print(f"INFO: txt_value: {self.txt_value}")
-        print(f"INFO: second_level_domain_name: {self.second_level_domain_name}")
-        print(f"INFO: domain_name: {self.domain_name}")
-        print(f"INFO: subdomain: {self.subdomain}")
 
         # setup session for cookie sharing
         headers = {
@@ -59,11 +56,11 @@ class CertbotStratoApi:
         self.records = []
 
     def login_2fa(
-        self,
-        response: requests.Response,
-        username: str,
-        totp_secret: str,
-        totp_devicename: str,
+            self,
+            response: requests.Response,
+            username: str,
+            totp_secret: str,
+            totp_devicename: str,
     ) -> requests.Response:
         """Login with Two-factor authentication by TOTP on Strato website.
 
@@ -77,8 +74,8 @@ class CertbotStratoApi:
         # Is 2FA used
         soup = BeautifulSoup(response.text, "html.parser")
         if (
-            soup.find("h1", string=re.compile("Zwei\\-Faktor\\-Authentifizierung"))
-            is None
+                soup.find("h1", string=re.compile("Zwei\\-Faktor\\-Authentifizierung"))
+                is None
         ):
             print("INFO: 2FA is not used.")
             return response
@@ -103,9 +100,9 @@ class CertbotStratoApi:
         # TODO: rewrite with beautifulsoup
         # Set parameter pw_id
         for device in re.finditer(
-            rf'<option value="(?P<value>(S\.{username}\.\w*))"'
-            r'( selected(="selected")?)?\s*>(?P<name>(.+?))</option>',
-            response.text,
+                rf'<option value="(?P<value>(S\.{username}\.\w*))"'
+                r'( selected(="selected")?)?\s*>(?P<name>(.+?))</option>',
+                response.text,
         ):
             if totp_devicename.strip() == device.group("name").strip():
                 param["pw_id"] = device.group("value")
@@ -122,11 +119,11 @@ class CertbotStratoApi:
         return request
 
     def login(
-        self,
-        username: str,
-        password: str,
-        totp_secret: str = None,
-        totp_devicename: str = None,
+            self,
+            username: str,
+            password: str,
+            totp_secret: str = None,
+            totp_devicename: str = None,
     ) -> bool:
         """Login to Strato website. Requests session ID.
 
@@ -219,12 +216,12 @@ class CertbotStratoApi:
         # No idea what this regex does
         # TODO: rewrite with beautifulsoup
         for record in re.finditer(
-            r'<select [^>]*name="type"[^>]*>.*?'
-            r'<option[^>]*value="(?P<type>[^"]*)"[^>]*selected[^>]*>'
-            r".*?</select>.*?"
-            r'<input [^>]*value="(?P<prefix>[^"]*)"[^>]*name="prefix"[^>]*>'
-            r'.*?<textarea [^>]*name="value"[^>]*>(?P<value>.*?)</textarea>',
-            request.text,
+                r'<select [^>]*name="type"[^>]*>.*?'
+                r'<option[^>]*value="(?P<type>[^"]*)"[^>]*selected[^>]*>'
+                r".*?</select>.*?"
+                r'<input [^>]*value="(?P<prefix>[^"]*)"[^>]*name="prefix"[^>]*>'
+                r'.*?<textarea [^>]*name="value"[^>]*>(?P<value>.*?)</textarea>',
+                request.text,
         ):
             self.records.append(
                 {
@@ -265,20 +262,18 @@ class CertbotStratoApi:
         """
         for i in reversed(range(len(self.records))):
             if (
-                self.records[i]["prefix"] == prefix
-                and self.records[i]["type"] == record_type
+                    self.records[i]["prefix"] == prefix
+                    and self.records[i]["type"] == record_type
             ):
                 self.records.pop(i)
 
     def set_amce_record(self) -> None:
         """Set or replace AMCE txt record on domain."""
-        key = f"{self.txt_key}.{self.subdomain}" if self.subdomain else self.txt_key
-        self.add_txt_record(key, "TXT", self.txt_value)
+        self.add_txt_record(self.txt_key, "TXT", self.txt_value)
 
     def reset_amce_record(self) -> None:
         """Reset AMCE txt record on domain."""
-        key = f"{self.txt_key}.{self.subdomain}" if self.subdomain else self.txt_key
-        self.remove_txt_record(key, "TXT")
+        self.remove_txt_record(self.txt_key, "TXT")
 
     def push_txt_records(self) -> None:
         """Push modified txt records to Strato."""

--- a/certbotstratoapi.py
+++ b/certbotstratoapi.py
@@ -198,7 +198,7 @@ class CertbotStratoApi:
                 "cID": self.package_id,
                 "node": "ManageDomains",
                 "action_show_txt_records": "",
-                "vhost": self.domain_name,
+                "vhost": self.second_level_domain_name,
             },
         )
         # No idea what this regex does
@@ -279,7 +279,7 @@ class CertbotStratoApi:
                 "sessionID": self.session_id,
                 "cID": self.package_id,
                 "node": "ManageDomains",
-                "vhost": self.domain_name,
+                "vhost": self.second_level_domain_name,
                 "spf_type": "NONE",
                 "prefix": [r["prefix"] for r in self.records],
                 "type": [r["type"] for r in self.records],


### PR DESCRIPTION
During the integration into [cert-manager-webhook-strato](https://github.com/antiFetzen/cert-manager-webhook-strato)
I struggled with presenting ACME-challenges for subdomains.

# Issue

In the current version I couldn't create a record for a domain like `subdomain.example.com`.

Parameter set:

## Test cases


### 1. ✅ Add record for `example.com`

```bash
CERTBOT_DOMAIN=example.com CERTBOT_VALIDATION=token-txt-value python auth-hook.py
```

**Result**
- Works as expected and record `_acme-challenge.example.com` was created.


### 2. 🚫 Add record for `subdomain.example.com`

```bash
CERTBOT_DOMAIN=subdomain.example.com CERTBOT_VALIDATION=token-txt-value python auth-hook.py
```

**Result**
- No record was created and no existing record could be read form Strato.

**Log**
```
...
INFO: Current cname/txt records:
INFO: New cname/txt records:
INFO: - _acme-challenge.subdomain TXT: token-txt-value
```


### 3. 🚫 Add record for `next.subdomain.example.com`

```bash
CERTBOT_DOMAIN=next.subdomain.example.com CERTBOT_VALIDATION=token-txt-value python auth-hook.py
```

**Result**
- No record was created and no existing record could be read form Strato.

**Log**
```
...
INFO: Current cname/txt records:
INFO: New cname/txt records:
INFO: - _acme-challenge.next.subdomain TXT: token-txt-value
```


### 4. 🚫 Add record for `_acme-challenge.next.subdomain.example.com`

```bash
CERTBOT_DOMAIN=_acme-challenge.next.subdomain.example.com CERTBOT_VALIDATION=token-txt-value python auth-hook.py
```

- No record was created and no existing record could be read form Strato.
- Duplication of the acme-challenge label.

**Log**
```
...
INFO: Current cname/txt records:
INFO: New cname/txt records:
INFO: - _acme-challenge._acme-challenge.next.subdomain TXT: token-txt-value
```


# Analysis

```bash
CERTBOT_DOMAIN=next.subdomain.example.com CERTBOT_VALIDATION=token-txt-value python auth-hook.py
```

**Domain data**
```
INFO: txt_key: _acme-challenge
INFO: txt_value: token-txt-value
INFO: second_level_domain_name: example.com
INFO: domain_name: next.subdomain.example.com
INFO: subdomain: next.subdomain
```

By requesting the record the method `get_txt_record()` could not find anyone.

**certbotstratoapi.py:194**
```python
def get_txt_records(self) -> None:
    """Requests all txt and cname records related to domain."""
    request = self.http_session.get(
        self.api_url,
        params={
            "sessionID": self.session_id,
            "cID": self.package_id,
            "node": "ManageDomains",
            "action_show_txt_records": "",
            "vhost": self.domain_name,
        },
    )
    ...
```

The request asks for records page of the `vhost = next.subdomain.example.com`.
=> This will return the general overview page, because the `vhost` does not exist.

## ✏️ Modification

### Main change
Change `vhost` from `self.domain_name` to `self.second_level_domain_name` in:
- `get_txt_records()`
- `push_txt_records()`

### Cert-manager adjustments
- Create unification of `CERTBOT_DOMAIN` to support multiple variants
  - With acme-challenge label: `_acme-challenge.subdomain.example.com`
  - Fqdn with root-level period: `example.com.`
- Add examples to the different domain types
- Do some small refinements


## Final tests

- 1. ✅ Add record for `example.com`
- 2. ✅ Add record for `subdomain.example.com`
- 3. ✅ Add record for `next.subdomain.example.com`
- 4. ✅ Add record for `_acme-challenge.next.subdomain.example.com`
- 5. ✅ Add record for `_acme-challenge.next.subdomain.example.com.`

    
Both hooks `auth-hook` and `cleanup-hook` working now as expected! 🥳




